### PR TITLE
Add environment variable configuration

### DIFF
--- a/project/latency_monitor.py
+++ b/project/latency_monitor.py
@@ -2,7 +2,7 @@ import requests
 import time
 import os
 
-PAGERDUTY_KEY = os.getenv("PD_ROUTING_KEY")
+PAGERDUTY_KEY = os.getenv("PD_ROUTING_KEY", "")
 ALERT_THRESHOLD = 10  # seconds
 
 FEEDS = {
@@ -14,7 +14,7 @@ FEEDS = {
 def send_pagerduty_alert(feed_name, latency):
     summary = f"🚨 {feed_name.capitalize()} metadata feed response time error ({latency:.2f}s)"
     payload = {
-        "routing_key": be2800efd3ac410fc05d30cea86764f9,
+        "routing_key": f"{PAGERDUTY_KEY}",
         "event_action": "trigger",
         "payload": {
             "summary": summary,

--- a/project/main.py
+++ b/project/main.py
@@ -9,6 +9,7 @@ import httpx
 import asyncio
 import json
 import logging
+import os
 import redis.asyncio as redis
 import hashlib
 import requests
@@ -17,8 +18,9 @@ import secrets
 app = FastAPI()
 security = HTTPBasic()
 
-USERNAME = "admin"
-PASSWORD = "familyradio2025"
+USERNAME = os.getenv("ADMIN_USER", "admin")
+PASSWORD = os.getenv("ADMIN_PASSWORD", "familyradio2025")
+PAGERDUTY_KEY = os.getenv("PD_ROUTING_KEY", "be2800efd3ac410fc05d30cea86764f9")
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -30,7 +32,9 @@ app.add_middleware(
     allow_headers=["*"]
 )
 
-rdb = redis.Redis(host="localhost", port=6379, decode_responses=True)
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+rdb = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
 
 HTML_TEMPLATE = """<!DOCTYPE html>
 <html>
@@ -309,7 +313,7 @@ async def trigger_test_alert(credentials: HTTPBasicCredentials = Depends(securit
     ):
         return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
 
-    pagerduty_key = "be2800efd3ac410fc05d30cea86764f9"
+    pagerduty_key = PAGERDUTY_KEY
     payload = {
         "routing_key": pagerduty_key,
         "event_action": "trigger",


### PR DESCRIPTION
## Summary
- read admin credentials from `ADMIN_USER` and `ADMIN_PASSWORD`
- read PagerDuty routing key from `PD_ROUTING_KEY`
- configure Redis host/port using `REDIS_HOST` and `REDIS_PORT`
- fix `latency_monitor` to use the env-provided PagerDuty key

## Testing
- `python -m py_compile project/main.py project/latency_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_68657eab309883229bb00c1b66e37967