### PR TITLE
Add httpx and redis dependencies

### DIFF
--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -2,4 +2,6 @@ fastapi
 uvicorn
 requests
 pytz
+httpx==0.28.1
+redis==5.3.0
 


### PR DESCRIPTION
## Summary
- add httpx and redis libraries to the `project` requirements list

## Testing
- `python -m pip install -r project/requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68658071f1f48322b356bd1afb0b62e4