### PR TITLE
Fix admin_dashboard syntax

### DIFF
--- a/project/main.py
+++ b/project/main.py
@@ -247,10 +247,6 @@ async def feed_fifth(request: Request):
     await increment_metrics("fifth", client_id)
     data = await fetch_tracks(SOURCE_FIFTH)
     return JSONResponse({"nowPlaying": await to_spec_format(data)})
-
-@app.get("/admin/dashboard")
-async def admin_dashboard():
-
 @app.get("/admin/dashboard", response_class=HTMLResponse)
 async def admin_dashboard(request: Request):
 


### PR DESCRIPTION
## Summary
- remove stray decorator that produced a syntax error in `admin_dashboard`

## Testing
- `python -m py_compile project/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68658cc6dfc48322b872e5ba40e6a767