### PR TITLE
Handle Family Radio metadata without artwork

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,7 +90,10 @@ def to_spec_format(raw_tracks):
         album  = t.get("TALB", title)
         start  = t.get("start_time", datetime.now().timestamp())
         ts     = datetime.fromtimestamp(start, tz=central).isoformat()
-        meta   = lookup_album_art(artist, album)
+        if artist.strip().lower() == "family radio" or title.strip().lower() == "family radio":
+            meta = {"imageUrl": "", "itunesTrackUrl": "", "previewUrl": ""}
+        else:
+            meta   = lookup_album_art(artist, album)
         out.append({
             "id": str(uuid.uuid4()),
             "artist": artist,

--- a/main.py
+++ b/main.py
@@ -285,7 +285,10 @@ async def to_spec_format(raw_tracks):
         title = t.get("TIT2", "")
         album_csv = get_csv_album(artist, title)
         album = album_csv or t.get("TALB", title)
-        tasks.append(lookup_album_art(artist, album))
+        if artist.strip().lower() == "family radio" or title.strip().lower() == "family radio":
+            tasks.append(asyncio.sleep(0, result={"imageUrl": "", "itunesTrackUrl": "", "previewUrl": ""}))
+        else:
+            tasks.append(lookup_album_art(artist, album))
     metadatas = await asyncio.gather(*tasks)
     formatted = []
     for idx, (t, meta) in enumerate(zip(raw_tracks, metadatas)):


### PR DESCRIPTION
## Summary
- when artist or title is `Family Radio` don't fetch album art

## Testing
- `python -m py_compile app.py main.py latency_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_6883c154dd00832284b29f16d887eb43