### PR TITLE
Fix track status ordering

### DIFF
--- a/main.py
+++ b/main.py
@@ -297,7 +297,7 @@ async def to_spec_format(raw_tracks):
             tasks.append(lookup_album_art(artist, album))
     metadatas = await asyncio.gather(*tasks)
     formatted = []
-    for idx, (t, meta) in enumerate(zip(raw_tracks, metadatas)):
+    for t, meta in zip(raw_tracks, metadatas):
         artist = t.get("TPE1", "Family Radio")
         title = t.get("TIT2", "")
         album_csv = get_csv_album(artist, title)
@@ -319,12 +319,14 @@ async def to_spec_format(raw_tracks):
             "itunesTrackUrl": meta["itunesTrackUrl"],
             "previewUrl": meta["previewUrl"],
             "duration": t.get("duration", "00:03:00"),
-            "status": "playing" if idx == 0 else "history",
+            "status": "history",
             "type": "song",
             "_ts": float(played_on),
         })
 
     formatted.sort(key=lambda x: x["_ts"], reverse=True)
+    if formatted:
+        formatted[0]["status"] = "playing"
     for f in formatted:
         f.pop("_ts", None)
 


### PR DESCRIPTION
## Summary
- update `to_spec_format` in both apps so playing/history is set after sorting
- clean up unused branches and ensure `_ts` is removed before returning

## Testing
- `python -m py_compile main.py app.py`
- `python - <<'PY'
from main import to_spec_format
import asyncio
sample=[{"TPE1":"Family Radio","TIT2":"Song1","played_on":1000},{"TPE1":"Family Radio","TIT2":"Song2","played_on":2000},{"TPE1":"Family Radio","TIT2":"Song3","played_on":1500}]
print(asyncio.run(to_spec_format(sample)))
PY`
- `python - <<'PY'
from app import to_spec_format
sample=[{"TPE1":"Family Radio","TIT2":"Song1","start_time":1000},{"TPE1":"Family Radio","TIT2":"Song2","start_time":2000},{"TPE1":"Family Radio","TIT2":"Song3","start_time":1500}]
print(to_spec_format(sample))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6883e28c14808322b80d54699089c14d