### PR TITLE
Fix duplicate entries in history

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,8 +94,12 @@ def to_spec_format(raw_tracks):
         artist = t.get("TPE1", "Family Radio")
         title = t.get("TIT2", "")
         album = t.get("TALB", title)
-        start = t.get("start_time", datetime.now().timestamp())
-        ts_dt = datetime.fromtimestamp(float(start), tz=central)
+        played_on = (
+            t.get("played_on")
+            or t.get("last_seen")
+            or datetime.now().timestamp()
+        )
+        ts_dt = datetime.fromtimestamp(float(played_on), tz=central)
 
         if is_family_radio(artist, title):
             meta = EMPTY_META
@@ -114,16 +118,26 @@ def to_spec_format(raw_tracks):
             "duration": t.get("duration", "00:03:00"),
             "status": "history",
             "type": "song",
-            "_ts": float(start),
+            "_ts": float(played_on),
         })
 
     out.sort(key=lambda x: x["_ts"], reverse=True)
-    if out:
-        out[0]["status"] = "playing"
+
+    seen = set()
+    deduped = []
     for item in out:
+        key = (item["artist"].lower().strip(), item["title"].lower().strip())
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    if deduped:
+        deduped[0]["status"] = "playing"
+
+    for item in deduped:
         item.pop("_ts", None)
 
-    return out
+    return deduped
 
 # -------------- ROUTES -----------------
 

--- a/main.py
+++ b/main.py
@@ -325,12 +325,22 @@ async def to_spec_format(raw_tracks):
         })
 
     formatted.sort(key=lambda x: x["_ts"], reverse=True)
-    if formatted:
-        formatted[0]["status"] = "playing"
-    for f in formatted:
+
+    seen = set()
+    deduped = []
+    for item in formatted:
+        key = (item["artist"].lower().strip(), item["title"].lower().strip())
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    if deduped:
+        deduped[0]["status"] = "playing"
+
+    for f in deduped:
         f.pop("_ts", None)
 
-    return formatted
+    return deduped
 
 def get_client_id(request: Request):
     return request.client.host


### PR DESCRIPTION
## Summary
- deduplicate tracks in `to_spec_format`
- apply the same dedupe logic in both implementations
- use `played_on` timestamps in the Flask version for proper ordering

## Testing
- `python -m py_compile main.py app.py latency_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_6883e12cdb4483228fcc03f3f7136f3e